### PR TITLE
Declare class properties explicitly to avoid deprecation warnings

### DIFF
--- a/lib/Laposta/Error.php
+++ b/lib/Laposta/Error.php
@@ -1,6 +1,10 @@
 <?php
 class Laposta_Error extends Exception {
 
+	public $http_status;
+	public $http_body;
+	public $json_body;
+
 	public function __construct($message=null, $http_status=null, $http_body=null, $json_body=null) {
 
 		parent::__construct($message);


### PR DESCRIPTION
From PHP 8.2 on, dynamic class properties are deprecated. Declaring these explicitly will prevent the deprecation warnings.